### PR TITLE
Fix tflint and checkov warnings

### DIFF
--- a/04/src/main.tf
+++ b/04/src/main.tf
@@ -7,7 +7,7 @@ module "vpc" {
 }
 
 module "test-vm" {
-  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=1.0.0"
   env_name        = "develop"
 #  network_id      = yandex_vpc_network.develop.id
   network_id      = module.vpc.vpc_id
@@ -16,7 +16,8 @@ module "test-vm" {
   instance_name   = "web"
   instance_count  = 1
   image_family    = "ubuntu-2004-lts"
-  public_ip       = true
+#  public_ip       = true
+  security_group_ids = [yandex_vpc_security_group.example.id]
   
   metadata = {
     user-data          = data.template_file.userdata.rendered

--- a/04/src/providers.tf
+++ b/04/src/providers.tf
@@ -3,6 +3,10 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = ">=0.92"
+    }
+    template = {
+      version = ">=0.01"
     }
   }
   required_version = ">=0.13"

--- a/04/src/providers.tf
+++ b/04/src/providers.tf
@@ -11,17 +11,17 @@ terraform {
   }
   required_version = ">=0.13"
 
-  backend "s3" {
-    endpoint   = "storage.yandexcloud.net"
-    bucket     = "bucket-for-terraform"
-    region     = "ru-central1"
-    key        = "terraform-tfstate"
-
-    skip_region_validation      = true
-    skip_credentials_validation = true
-    dynamodb_endpoint = "https://docapi.serverless.yandexcloud.net/ru-central1/b1ge8m51046pv654acbv/etnoj5a7tvqiqh4j1bnj"
-    dynamodb_table = "tfstate-lock"
-  }
+#  backend "s3" {
+#    endpoint   = "storage.yandexcloud.net"
+#    bucket     = "bucket-for-terraform"
+#    region     = "ru-central1"
+#    key        = "terraform-tfstate"
+#
+#    skip_region_validation      = true
+#    skip_credentials_validation = true
+#    dynamodb_endpoint = "https://docapi.serverless.yandexcloud.net/ru-central1/b1ge8m51046pv654acbv/etnoj5a7tvqiqh4j1bnj"
+#    dynamodb_table = "tfstate-lock"
+#  }
 }
 
 

--- a/04/src/security.tf
+++ b/04/src/security.tf
@@ -1,0 +1,86 @@
+variable "security_group_ingress" {
+  description = "secrules ingress"
+  type = list(object(
+    {
+      protocol       = string
+      description    = string
+      v4_cidr_blocks = list(string)
+      port           = optional(number)
+      from_port      = optional(number)
+      to_port        = optional(number)
+  }))
+  default = [
+    {
+      protocol       = "TCP"
+      description    = "разрешить входящий ssh"
+      v4_cidr_blocks = ["0.0.0.0/0"]
+      port           = 22
+    },
+    {
+      protocol       = "TCP"
+      description    = "разрешить входящий  http"
+      v4_cidr_blocks = ["0.0.0.0/0"]
+      port           = 80
+    },
+    {
+      protocol       = "TCP"
+      description    = "разрешить входящий https"
+      v4_cidr_blocks = ["0.0.0.0/0"]
+      port           = 443
+    },
+  ]
+}
+
+
+variable "security_group_egress" {
+  description = "secrules egress"
+  type = list(object(
+    {
+      protocol       = string
+      description    = string
+      v4_cidr_blocks = list(string)
+      port           = optional(number)
+      from_port      = optional(number)
+      to_port        = optional(number)
+  }))
+  default = [
+    { 
+      protocol       = "TCP"
+      description    = "разрешить весь исходящий трафик"
+      v4_cidr_blocks = ["0.0.0.0/0"]
+      from_port      = 0
+      to_port        = 65365
+    }
+  ]
+}
+
+
+resource "yandex_vpc_security_group" "example" {
+  name       = "example_dynamic"
+  network_id = module.vpc.subnet_id
+  folder_id  = var.folder_id
+
+  dynamic "ingress" {
+    for_each = var.security_group_ingress
+    content {
+      protocol       = lookup(ingress.value, "protocol", null)
+      description    = lookup(ingress.value, "description", null)
+      port           = lookup(ingress.value, "port", null)
+      from_port      = lookup(ingress.value, "from_port", null)
+      to_port        = lookup(ingress.value, "to_port", null)
+      v4_cidr_blocks = lookup(ingress.value, "v4_cidr_blocks", null)
+    }
+  }
+
+  dynamic "egress" {
+    for_each = var.security_group_egress
+    content {
+      protocol       = lookup(egress.value, "protocol", null)
+      description    = lookup(egress.value, "description", null)
+      port           = lookup(egress.value, "port", null)
+      from_port      = lookup(egress.value, "from_port", null)
+      to_port        = lookup(egress.value, "to_port", null)
+      v4_cidr_blocks = lookup(egress.value, "v4_cidr_blocks", null)
+    }
+  }
+}

--- a/04/src/variables.tf
+++ b/04/src/variables.tf
@@ -19,39 +19,3 @@ variable "default_zone" {
   default     = "ru-central1-a"
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
-variable "default_cidr" {
-  type        = list(string)
-  default     = ["10.0.1.0/24"]
-  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
-}
-
-variable "vpc_name" {
-  type        = string
-  default     = "develop"
-  description = "VPC network&subnet name"
-}
-
-###common vars
-
-variable "vms_ssh_root_key" {
-  type        = string
-  default     = "your_ssh_ed25519_key"
-  description = "ssh-keygen -t ed25519"
-}
-
-###example vm_web var
-variable "vm_web_name" {
-  type        = string
-  default     = "netology-develop-platform-web"
-  description = "example vm_web_ prefix"
-}
-
-###example vm_db var
-variable "vm_db_name" {
-  type        = string
-  default     = "netology-develop-platform-db"
-  description = "example vm_db_ prefix"
-}
-
-
-

--- a/04/src/variables.tf
+++ b/04/src/variables.tf
@@ -19,3 +19,29 @@ variable "default_zone" {
   default     = "ru-central1-a"
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
+
+variable "ipv4_addr" {
+  type    = string
+  default = "192.168.0.1"
+#  default = "1920.1680.0.1"
+  description = "ip-адрес"
+
+  validation {
+    condition     = can(cidrhost(join("/", [var.ipv4_addr, 32]), 0))
+    error_message = "Invalid IPv4 address."
+  }
+}
+
+variable "ipv4_addr_list" {
+  type    = list(string)
+#  default = ["192.168.0.1", "1.1.1.1", "127.0.0.1"]
+  default = ["192.168.0.1", "1.1.1.1", "1270.0.0.1"]
+  description = "список ip-адресов"
+
+  validation {
+    condition = alltrue([
+      for a in var.ipv4_addr_list : can(cidrhost(join("/", [a, 32]), 0))
+    ])
+    error_message = "All elements must be valid IPv4 addresses."
+  }
+}

--- a/04/src/variables.tf
+++ b/04/src/variables.tf
@@ -34,8 +34,8 @@ variable "ipv4_addr" {
 
 variable "ipv4_addr_list" {
   type    = list(string)
-#  default = ["192.168.0.1", "1.1.1.1", "127.0.0.1"]
-  default = ["192.168.0.1", "1.1.1.1", "1270.0.0.1"]
+  default = ["192.168.0.1", "1.1.1.1", "127.0.0.1"]
+#  default = ["192.168.0.1", "1.1.1.1", "1270.0.0.1"]
   description = "список ip-адресов"
 
   validation {
@@ -44,4 +44,38 @@ variable "ipv4_addr_list" {
     ])
     error_message = "All elements must be valid IPv4 addresses."
   }
+}
+
+variable "lowercase_string" {
+  type        = string
+  description = "любая строка"
+#  default     = "asdfjhasdfj`1234n./,/"
+  default     = "asdfjXhasdfj`1234n./,/"
+
+  validation {
+    condition     = var.lowercase_string == lower(var.lowercase_string)
+    error_message = "String contains uppercase letters."
+  }
+}
+
+variable "in_the_end_there_can_be_only_one" {
+    description="Who is better Connor or Duncan?"
+    type = object({
+        Dunkan = optional(bool)
+        Connor = optional(bool)
+    })
+
+#    default = {
+#        Dunkan = true
+#        Connor = false
+#    }
+    default = {
+        Dunkan = true
+        Connor = true
+    }
+
+    validation {
+        error_message = "There can be only one MacLeod"
+        condition     = !(var.in_the_end_there_can_be_only_one.Dunkan && var.in_the_end_there_can_be_only_one.Connor)
+    }
 }

--- a/04/src/variables.tf
+++ b/04/src/variables.tf
@@ -59,7 +59,7 @@ variable "lowercase_string" {
 }
 
 variable "in_the_end_there_can_be_only_one" {
-    description="Who is better Connor or Duncan?"
+    description = "Who is better Connor or Duncan?"
     type = object({
         Dunkan = optional(bool)
         Connor = optional(bool)

--- a/README.md
+++ b/README.md
@@ -237,3 +237,223 @@
    Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
    fedor@fedor-Z68P-DS3:~/CODE/Netology/DevOps/ter-homeworks/04/src$
    ```
+
+4. **Измените модуль vpc так, чтобы он мог создать подсети во всех зонах доступности, переданных в переменной типа list(object) при вызове модуля.**
+
+   **Предоставьте код, план выполнения, результат из консоли YC.**
+   
+   Привожу код в [отдельной ветке](https://github.com/fedor-metsger/ter-homeworks/tree/terraform-04-add/04/src).
+   
+   Привожу скриншоты с YC:
+   
+   ![](https://github.com/fedor-metsger/devops-netology/blob/main/Capture29.png)
+   
+   ![](https://github.com/fedor-metsger/devops-netology/blob/main/Capture30.png)
+   
+   План выполнения:
+   ```
+   module.test-vm.data.yandex_compute_image.my_image: Reading...
+   data.template_file.userdata: Reading...
+   data.template_file.userdata: Read complete after 0s [id=a188abb0daeef04def27c9164c98402a79667f6164cd2816a7b9664d4afba9a1]
+   module.test-vm.data.yandex_compute_image.my_image: Read complete after 3s [id=fd8lape4adm5melne14m]
+
+   Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
+     + create
+
+   Terraform will perform the following actions:
+
+     # module.test-vm.yandex_compute_instance.vm[0] will be created
+         + resource "yandex_compute_instance" "vm" {
+         + allow_stopping_for_update = true
+         + created_at                = (known after apply)
+         + description               = "TODO: description; {{terraform managed}}"
+         + folder_id                 = (known after apply)
+         + fqdn                      = (known after apply)
+         + gpu_cluster_id            = (known after apply)
+         + hostname                  = "develop-web-0"
+         + id                        = (known after apply)
+         + labels                    = {
+             + "env"     = "develop"
+             + "project" = "undefined"
+           }
+         + metadata                  = {
+             + "serial-port-enable" = "1"
+             + "user-data"          = <<-EOT
+                   #cloud-config
+                   users:
+                     - name: ubuntu
+                       groups: sudo
+                       shell: /bin/bash
+                       sudo: ['ALL=(ALL) NOPASSWD:ALL']
+                       ssh-authorized-keys:
+                            - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDmAQm4S2bJ8BP+Cj+9JNcAQcGhhieeYwcxglNJN7+zDvZhg/7PsxcdYWKcwuQEP6Eu7LylGyKIoMMM1nJ/xojJx6p4mkMbNZI239Bkju5+pej0OJSCPTZjMTsOp0RkGmeMuvFEE89MsGCU1hf6AZwBR5Jtn4SrHS5GAXwxgNA6zK/BcI7fhNflhMIcfvBYq1+y/s5f6EniUTMtijIW3aWVr4rdWKsznlTkQpPlI2Rr6Qzy5OsoS2gk0+rFD2V7rzVe9Djplp5taxqVY1oA0MpoqM10gQoxaY12GIK0WElMMjFzeysV21IdI345015tTmXxS2EVryUrWsS4BryhbnansDUgihI1Sr5kKeEeK9d3Wqi6uFDcDwizB3Cne7dr0RpT+7gpbvTMyM6AB1ON3MrE28GDUNjTlaEgRyRvYynIx/bEVIO+XvBDUt2oQdG7dbGPcWppfjkAkJsVcfSRamwSEoD0c5BmJAcp9ez70rUME5n3WUhuWrpbcehY1jMv58M= fedor@DESKTOP-FEKCCDN
+                
+                   package_update: true
+                   package_upgrade: false
+                   packages:
+                     - vim
+                     - nginx
+               EOT
+           }
+         + name                      = "develop-web-0"
+         + network_acceleration_type = "standard"
+         + platform_id               = "standard-v1"
+         + service_account_id        = (known after apply)
+         + status                    = (known after apply)
+         + zone                      = "ru-central1-a"
+
+         + boot_disk {
+             + auto_delete = true
+             + device_name = (known after apply)
+             + disk_id     = (known after apply)
+             + mode        = (known after apply)
+   
+             + initialize_params {
+                 + block_size  = (known after apply)
+                 + description = (known after apply)
+                 + image_id    = "fd8lape4adm5melne14m"
+                 + name        = (known after apply)
+                 + size        = 10
+                 + snapshot_id = (known after apply)
+                 + type        = "network-hdd"
+               }
+           }
+   
+         + network_interface {
+             + index              = (known after apply)
+             + ip_address         = (known after apply)
+             + ipv4               = true
+             + ipv6               = (known after apply)
+             + ipv6_address       = (known after apply)
+             + mac_address        = (known after apply)
+             + nat                = true
+             + nat_ip_address     = (known after apply)
+             + nat_ip_version     = (known after apply)
+             + security_group_ids = (known after apply)
+             + subnet_id          = (known after apply)
+           }
+
+         + resources {
+             + core_fraction = 5
+             + cores         = 2
+             + memory        = 1
+           }
+
+         + scheduling_policy {
+             + preemptible = true
+           }
+       }
+
+     # module.vpc_dev.yandex_vpc_network.net_name will be created
+     + resource "yandex_vpc_network" "net_name" {
+         + created_at                = (known after apply)
+         + default_security_group_id = (known after apply)
+         + folder_id                 = (known after apply)
+         + id                        = (known after apply)
+         + labels                    = (known after apply)
+         + name                      = "develop"
+         + subnet_ids                = (known after apply)
+       }
+
+     # module.vpc_dev.yandex_vpc_subnet.subnet_name[0] will be created
+     + resource "yandex_vpc_subnet" "subnet_name" {
+         + created_at     = (known after apply)
+         + folder_id      = (known after apply)
+         + id             = (known after apply)
+         + labels         = (known after apply)
+         + name           = "develop-ru-central1-a"
+         + network_id     = (known after apply)
+         + v4_cidr_blocks = [
+             + "10.0.1.0/24",
+           ]
+         + v6_cidr_blocks = (known after apply)
+         + zone           = "ru-central1-a"
+       }
+
+     # module.vpc_prod.yandex_vpc_network.net_name will be created
+     + resource "yandex_vpc_network" "net_name" {
+         + created_at                = (known after apply)
+         + default_security_group_id = (known after apply)
+         + folder_id                 = (known after apply)
+         + id                        = (known after apply)
+         + labels                    = (known after apply)
+         + name                      = "production"
+         + subnet_ids                = (known after apply)
+       }
+
+     # module.vpc_prod.yandex_vpc_subnet.subnet_name[0] will be created
+     + resource "yandex_vpc_subnet" "subnet_name" {
+         + created_at     = (known after apply)
+         + folder_id      = (known after apply)
+         + id             = (known after apply)
+         + labels         = (known after apply)
+         + name           = "production-ru-central1-a"
+         + network_id     = (known after apply)
+         + v4_cidr_blocks = [
+             + "10.0.1.0/24",
+           ]
+         + v6_cidr_blocks = (known after apply)
+         + zone           = "ru-central1-a"
+     }
+
+     # module.vpc_prod.yandex_vpc_subnet.subnet_name[1] will be created
+       + resource "yandex_vpc_subnet" "subnet_name" {
+       + created_at     = (known after apply)
+       + folder_id      = (known after apply)
+       + id             = (known after apply)
+       + labels         = (known after apply)
+       + name           = "production-ru-central1-b"
+       + network_id     = (known after apply)
+       + v4_cidr_blocks = [
+           + "10.0.2.0/24",
+         ]
+       + v6_cidr_blocks = (known after apply)
+       + zone           = "ru-central1-b"
+     }
+
+     # module.vpc_prod.yandex_vpc_subnet.subnet_name[2] will be created
+     + resource "yandex_vpc_subnet" "subnet_name" {
+         + created_at     = (known after apply)
+         + folder_id      = (known after apply)
+         + id             = (known after apply)
+         + labels         = (known after apply)
+         + name           = "production-ru-central1-c"
+         + network_id     = (known after apply)
+         + v4_cidr_blocks = [
+             + "10.0.3.0/24",
+           ]
+         + v6_cidr_blocks = (known after apply)
+         + zone           = "ru-central1-c"
+     }
+
+   Plan: 7 to add, 0 to change, 0 to destroy.
+   ```
+   
+6. **Разверните у себя локально vault, используя docker-compose.yml в проекте.**
+   
+   **Для входа в web интерфейс и авторизации terraform в vault используйте токен "education"**
+   **Создайте новый секрет по пути http://127.0.0.1:8200/ui/vault/secrets/secret/create   
+   Path: example
+   secret data key: test secret data value: congrats!**
+   
+   **Считайте данный секрет с помощью terraform и выведите его в output**
+   
+   Привожу модуль [vault](https://github.com/fedor-metsger/ter-homeworks/tree/terraform-04-add/04/src/vault)
+   
+   Привожу вывод команды:
+   ```
+   fedor@fedor-Z68P-DS3:~/CODE/Netology/DevOps/ter-homeworks/04/src$ terraform output
+   vault_secret = tomap({
+     "test" = "congrats!"
+   })
+   fedor@fedor-Z68P-DS3:~/CODE/Netology/DevOps/ter-homeworks/04/src$
+   ```
+   
+   **Попробуйте самостоятельно разобраться в документации и записать новый секрет в vault с помощью terraform.**
+   
+   Привожу скриншот из консоли **Vault**:
+   
+   ![](https://github.com/fedor-metsger/devops-netology/blob/main/Capture31.png)
+   
+   
+   

--- a/README.md
+++ b/README.md
@@ -1,23 +1,98 @@
-# Домашние задания по модулю «Облачная инфраструктура. Terraform»
+# Домашнее задание к занятию «Использование Terraform в команде»
 
-В этом репозитории расположены ваши домашние задания к каждой лекции. 
+1. **Проверьте код с помощью tflint и checkov. Вам не нужно инициализировать этот проект.**
 
-Обязательными к выполнению являются задачи без указания звездочки. Их выполнение необходимо для получения зачета и диплома о профессиональной переподготовке.
+   **Перечислите какие типы ошибок обнаружены в проекте (без дублей).**
+   
+   Ответ:  
+   Ошибки **tflint**:
+   - Module source "..." uses a default branch as ref (main)
+   - Missing version constraint for provider "..." in "..."
+   - variable "..." is declared but not used
+   
+   Ошибки **checkov**:
+   - CKV_YC_4: "Ensure compute instance does not have serial console enabled." - **не обнаружена**
+   - CKV_YC_2: "Ensure compute instance does not have public IP." - **обнаружена**
+   - CKV_YC_11: "Ensure security group is assigned to network interface." - **обнаружена**
+   - CKV_YC_19: "Ensure security group does not contain allow-all rules." - **не обнаружена**
+   
+2. **Повторите демонстрацию лекции: настройте YDB, S3 bucket, yandex service account, права доступа и мигрируйте State проекта в S3 с блокировками. Предоставьте скриншоты процесса в качестве ответа.**
 
-Задачи со звездочкой (*) являются дополнительными задачами и/или задачами повышенной сложности. Они не являются обязательными к выполнению, но помогут вам глубже понять тему.
+   Настройка сервисного эккаунта:
+   
+   ![](https://github.com/fedor-metsger/devops-netology/blob/main/Screenshot%20at%202023-06-03%2017-31-15.png)
 
-Любые вопросы по решению задач задавайте в чате курса.
+   Настройка доступа к корзине:
+   
+   ![](https://github.com/fedor-metsger/devops-netology/blob/main/Screenshot%20at%202023-06-03%2017-32-34.png)
 
+   Переинициализация бекенда:
+   
+   ![](https://github.com/fedor-metsger/devops-netology/blob/main/Screenshot%20at%202023-06-03%2017-35-29.png)
 
-1. [Ввдение в Terraform](01/hw-01.md)
+   Создание БД для записи блокировок:
+   
+   ![](https://github.com/fedor-metsger/devops-netology/blob/main/Screenshot%20at%202023-06-03%2018-55-27.png)
 
-2. [Основы Terraform. Yandex Cloud](02/hw-02.md)
+   Миграция на конфигурацию с блокировками:
+   
+   ![](https://github.com/fedor-metsger/devops-netology/blob/main/Screenshot%20at%202023-06-03%2019-38-24.png)
 
-3. [Управляющие конструкции в коде Terraform](03/hw-03.md)
+   Записи блокировок в БД:
+   
+   ![](https://github.com/fedor-metsger/devops-netology/blob/main/Screenshot%20at%202023-06-03%2019-39-10.png)
 
-4. [Продвинутые методы работы с Terraform](04/hw-04.md)
+   **Откройте в проекте terraform console, а в другом окне из этой же директории попробуйте запустить terraform apply.**
+   **Пришлите ответ об ошибке доступа к State.**
 
-5. [Использование Terraform в команде](05/hw-05.md)
+   Ошибка **terraform apply** при заблокированной БД:
+   
+   ![](https://github.com/fedor-metsger/devops-netology/blob/main/Screenshot%20at%202023-06-03%2019-39-42.png)
 
+   **Принудительно разблокируйте State. Пришлите команду и вывод.**
 
+   Принудительное снятие блокировки:
+   
+   ![](https://github.com/fedor-metsger/devops-netology/blob/main/Screenshot%20at%202023-06-03%2019-41-39.png)
+   
+3. **Пришлите ссылку на PR для ревью(вливать код в 'terraform-05' не нужно).**
 
+   Ссылка на [Pull request](https://github.com/fedor-metsger/ter-homeworks/pull/1).
+   
+   В PR есть один конфликт в одном файле! Но он больше похож на какой то глюк гитхаба, так как выглядит выродженным,
+   или сделанным на пустом месте. Вернее пустое место конфликтует с удалением строк (вследствие чего, собственно,
+   и образовалось пустое место). Прилагаю скрин:
+   
+   ![](https://github.com/fedor-metsger/devops-netology/blob/main/Screenshot%20at%202023-06-04%2016-50-21.png)
+   
+   Конфликт я разрешил.
+   
+4. **Напишите переменные с валидацией и протестируйте их, заполнив default верными и неверными значениями. Предоставьте скриншоты проверок:**
+
+   **type=string, description="ip-адрес", проверка что значение переменной содержит верный IP-адрес с помощью функций cidrhost() или regex(). Тесты: "192.168.0.1" и "1920.1680.0.1"**
+   
+   Переменные описаны [здесь](https://github.com/fedor-metsger/ter-homeworks/blob/5dc4716c536fc23c134d9d1502c4fdd58529f0ac/04/src/variables.tf#L23).
+   
+   Прилагаю скриншот ошибки:
+   
+   ![](https://github.com/fedor-metsger/devops-netology/blob/main/Screenshot%20at%202023-06-03%2021-36-27.png)
+   
+   **type=list(string), description="список ip-адресов", проверка что все адреса верны. Тесты: ["192.168.0.1", "1.1.1.1", "127.0.0.1"] и ["192.168.0.1", "1.1.1.1", "1270.0.0.1"]**
+   
+   Прилагаю скриншот ошибки:
+   
+   ![](https://github.com/fedor-metsger/devops-netology/blob/main/Screenshot%20at%202023-06-03%2021-55-31.png)
+   
+5. **Напишите переменные с валидацией:**
+
+   **type=string, description="любая строка", проверка что строка не содержит в себе символов верхнего регистра**
+   
+   **type=object, проверка что введено только одно из опциональных значений по примеру:**
+   
+   Переменные описаны [здесь](https://github.com/fedor-metsger/ter-homeworks/blob/5dc4716c536fc23c134d9d1502c4fdd58529f0ac/04/src/variables.tf#L49).
+   
+   Результат проверки:
+   
+   ![](https://github.com/fedor-metsger/devops-netology/blob/main/Screenshot%20at%202023-06-04%2017-21-48.png)
+
+   

--- a/README.md
+++ b/README.md
@@ -1,23 +1,239 @@
-# Домашние задания по модулю «Облачная инфраструктура. Terraform»
+# Домашнее задание к занятию «Продвинутые методы работы с Terraform»
 
-В этом репозитории расположены ваши домашние задания к каждой лекции. 
+1. **Создайте 1 ВМ, используя данный модуль. В файле cloud-init.yml необходимо использовать переменную для ssh ключа вместо хардкода. Передайте ssh-ключ в функцию template_file в блоке vars ={} .**
+   **Воспользуйтесь примером. Обратите внимание что ssh-authorized-keys принимает в себя список, а не строку!**
 
-Обязательными к выполнению являются задачи без указания звездочки. Их выполнение необходимо для получения зачета и диплома о профессиональной переподготовке.
+   **Добавьте в файл cloud-init.yml установку nginx.**
+   
+   Привожу файл [cloud-init.yml](https://github.com/fedor-metsger/ter-homeworks/blob/terraform-04/04/src/cloud-init.yml):
 
-Задачи со звездочкой (*) являются дополнительными задачами и/или задачами повышенной сложности. Они не являются обязательными к выполнению, но помогут вам глубже понять тему.
+   ```
+   #cloud-config
+   users:
+     - name: ubuntu
+       groups: sudo
+       shell: /bin/bash
+       sudo: ['ALL=(ALL) NOPASSWD:ALL']
+       ssh-authorized-keys:
+         - ${ssh_public_key}
+   package_update: true
+   package_upgrade: false
+   packages:
+     - vim
+     - nginx
+   ```
 
-Любые вопросы по решению задач задавайте в чате курса.
+   **Предоставьте скриншот подключения к консоли и вывод команды** `sudo nginx -t`
+   
+   ```
+   fedor@fedor-Z68P-DS3:~/CODE/Netology/DevOps/ter-homeworks/04/src$ ssh ubuntu@51.250.73.175
+   The authenticity of host '51.250.73.175 (51.250.73.175)' can't be established.
+   ED25519 key fingerprint is SHA256:GkoDpnz53dS4GfPysge0t6XFFTPE+iEdV1CAuxf3xYc.
+   This key is not known by any other names
+   Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+   Warning: Permanently added '51.250.73.175' (ED25519) to the list of known hosts.
+   Welcome to Ubuntu 20.04.6 LTS (GNU/Linux 5.4.0-149-generic x86_64)
 
+    * Documentation:  https://help.ubuntu.com
+    * Management:     https://landscape.canonical.com
+    * Support:        https://ubuntu.com/advantage
 
-1. [Ввдение в Terraform](01/hw-01.md)
+   The programs included with the Ubuntu system are free software;
+   the exact distribution terms for each program are described in the
+   individual files in /usr/share/doc/*/copyright.
 
-2. [Основы Terraform. Yandex Cloud](02/hw-02.md)
+   Ubuntu comes with ABSOLUTELY NO WARRANTY, to the extent permitted by
+   applicable law.
 
-3. [Управляющие конструкции в коде Terraform](03/hw-03.md)
+   To run a command as administrator (user "root"), use "sudo <command>".
+   See "man sudo_root" for details.
 
-4. [Продвинутые методы работы с Terraform](04/hw-04.md)
+   ubuntu@develop-web-0:~$ nginx -t
 
-5. [Использование Terraform в команде](05/hw-05.md)
+   Command 'nginx' not found, but can be installed with:
 
+   sudo apt install nginx-core    # version 1.18.0-0ubuntu1.4, or
+   sudo apt install nginx-extras  # version 1.18.0-0ubuntu1.4
+   sudo apt install nginx-full    # version 1.18.0-0ubuntu1.4
+   sudo apt install nginx-light   # version 1.18.0-0ubuntu1.4
 
+   ubuntu@develop-web-0:~$
+   ```
 
+2. **Напишите локальный модуль vpc, который будет создавать 2 ресурса: одну сеть и одну подсеть в зоне, объявленной при вызове модуля. например: ru-central1-a.**
+   
+   **Модуль должен возвращать значения vpc.id и subnet.id**
+   
+   Прилагаю ссылку на модуль: [vpc](https://github.com/fedor-metsger/ter-homeworks/tree/terraform-04/04/src/vpc)
+
+   **Замените ресурсы yandex_vpc_network и yandex_vpc_subnet, созданным модулем.**
+   
+   Прилагаю файл [main.tf](https://github.com/fedor-metsger/ter-homeworks/blob/terraform-04/04/src/main.tf):
+   ```
+   module "vpc" {
+     source    = "./vpc"
+     env_name  = "develop"
+     zone      = "ru-central1-a"
+     cidr      = "10.0.1.0/24"
+   }
+
+   module "test-vm" {
+     source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+     env_name        = "develop"
+     network_id      = module.vpc.vpc_id
+     subnet_zones    = ["ru-central1-a"]
+     subnet_ids      = [ module.vpc.subnet_id ]
+     instance_name   = "web"
+     instance_count  = 1
+     image_family    = "ubuntu-2004-lts"
+     public_ip       = true
+  
+     metadata = {
+       user-data          = data.template_file.userdata.rendered
+       serial-port-enable = 1
+     }
+   }
+
+   data template_file "userdata" {
+     template = file("${path.module}/cloud-init.yml")
+
+     vars = {
+       ssh_public_key = file("~/.ssh/id_rsa.pub")
+     }
+   }
+   ```
+
+   **Сгенерируйте документацию к модулю с помощью terraform-docs.**
+   
+   Прилагаю вывод **terraform-docs**:
+   
+   ------------------------------------------------
+   ## Requirements
+
+   | Name | Version |
+   |------|---------|
+   | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13 |
+
+   ## Providers
+
+   | Name | Version |
+   |------|---------|
+   | <a name="provider_yandex"></a> [yandex](#provider\_yandex) | 0.92.0 |
+
+   ## Modules
+
+   No modules.
+
+   ## Resources
+
+   | Name | Type |
+   |------|------|
+   | [yandex_vpc_network.net_name](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/resources/vpc_network) | resource |
+   | [yandex_vpc_subnet.subnet_name](https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/resources/vpc_subnet) | resource |
+   
+   ## Inputs
+
+   | Name | Description | Type | Default | Required |
+   |------|-------------|------|---------|:--------:|
+   | <a name="input_cidr"></a> [cidr](#input\_cidr) | n/a | `string` | `"10.0.0.0/24"` | no |
+   | <a name="input_env_name"></a> [env\_name](#input\_env\_name) | Environment name | `string` | `"develop"` | no |
+   | <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name) | VPC network&subnet name | `string` | `"develop"` | no |
+   | <a name="input_zone"></a> [zone](#input\_zone) | https://cloud.yandex.ru/docs/overview/concepts/geo-scope | `string` | `"ru-central1-a"` | no |
+
+   ## Outputs
+
+   | Name | Description |
+   |------|-------------|
+   | <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | n/a |
+   | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | n/a |
+
+------------------------------------------
+
+3. **Выведите список ресурсов в стейте.**
+
+   **Удалите из стейта модуль vpc.**
+
+   **Импортируйте его обратно. Проверьте terraform plan - изменений быть не должно. Приложите список выполненных команд и вывод.**
+   
+   Прилагаю вывод команд:
+   
+   ```
+   fedor@fedor-Z68P-DS3:~/CODE/Netology/DevOps/ter-homeworks/04/src$ terraform state list
+   data.template_file.userdata
+   module.test-vm.data.yandex_compute_image.my_image
+   module.test-vm.yandex_compute_instance.vm[0]
+   module.vpc.yandex_vpc_network.net_name
+   module.vpc.yandex_vpc_subnet.subnet_name
+   fedor@fedor-Z68P-DS3:~/CODE/Netology/DevOps/ter-homeworks/04/src$ terraform state show module.vpc.yandex_vpc_network.net_name
+   \# module.vpc.yandex_vpc_network.net_name:
+   resource "yandex_vpc_network" "net_name" {
+       created_at = "2023-06-02T14:02:58Z"
+       folder_id  = "b1go2coto23a6o9qniv9"
+       id         = "enpjchrqk9unqff5gajr"
+       labels     = {}
+       name       = "develop"
+       subnet_ids = []
+   }
+   fedor@fedor-Z68P-DS3:~/CODE/Netology/DevOps/ter-homeworks/04/src$ terraform state show module.vpc.yandex_vpc_subnet.subnet_name
+   \# module.vpc.yandex_vpc_subnet.subnet_name:
+   resource "yandex_vpc_subnet" "subnet_name" {
+    created_at     = "2023-06-02T14:02:58Z"
+    folder_id      = "b1go2coto23a6o9qniv9"
+    id             = "e9b4go0gvvkq6q8plbf0"
+    labels         = {}
+    name           = "develop-ru-central1-a"
+    network_id     = "enpjchrqk9unqff5gajr"
+    v4_cidr_blocks = [
+        "10.0.1.0/24",
+    ]
+    v6_cidr_blocks = []
+    zone           = "ru-central1-a"
+   }
+   fedor@fedor-Z68P-DS3:~/CODE/Netology/DevOps/ter-homeworks/04/src$ terraform state rm 'module.vpc'
+   Removed module.vpc.yandex_vpc_network.net_name
+   Removed module.vpc.yandex_vpc_subnet.subnet_name
+   Successfully removed 2 resource instance(s).
+   fedor@fedor-Z68P-DS3:~/CODE/Netology/DevOps/ter-homeworks/04/src$ terraform import module.vpc.yandex_vpc_network.net_name enpjchrqk9unqff5gajr
+   data.template_file.userdata: Reading...
+   data.template_file.userdata: Read complete after 0s [id=a188abb0daeef04def27c9164c98402a79667f6164cd2816a7b9664d4afba9a1]
+   module.vpc.yandex_vpc_network.net_name: Importing from ID "enpjchrqk9unqff5gajr"...
+   module.vpc.yandex_vpc_network.net_name: Import prepared!
+     Prepared yandex_vpc_network for import
+   module.vpc.yandex_vpc_network.net_name: Refreshing state... [id=enpjchrqk9unqff5gajr]
+   module.test-vm.data.yandex_compute_image.my_image: Reading...
+   module.test-vm.data.yandex_compute_image.my_image: Read complete after 2s [id=fd8lape4adm5melne14m]
+
+   Import successful!
+
+   The resources that were imported are shown above. These resources are now in
+   your Terraform state and will henceforth be managed by Terraform.
+
+   fedor@fedor-Z68P-DS3:~/CODE/Netology/DevOps/ter-homeworks/04/src$ terraform import module.vpc.yandex_vpc_subnet.subnet_name e9b4go0gvvkq6q8plbf0
+   data.template_file.userdata: Reading...
+   data.template_file.userdata: Read complete after 0s [id=a188abb0daeef04def27c9164c98402a79667f6164cd2816a7b9664d4afba9a1]
+   module.test-vm.data.yandex_compute_image.my_image: Reading...
+   module.vpc.yandex_vpc_subnet.subnet_name: Importing from ID "e9b4go0gvvkq6q8plbf0"...
+   module.vpc.yandex_vpc_subnet.subnet_name: Import prepared!
+     Prepared yandex_vpc_subnet for import
+   module.vpc.yandex_vpc_subnet.subnet_name: Refreshing state... [id=e9b4go0gvvkq6q8plbf0]
+   module.test-vm.data.yandex_compute_image.my_image: Read complete after 2s [id=fd8lape4adm5melne14m]
+
+   Import successful!
+
+   The resources that were imported are shown above. These resources are now in
+   your Terraform state and will henceforth be managed by Terraform.
+
+   fedor@fedor-Z68P-DS3:~/CODE/Netology/DevOps/ter-homeworks/04/src$ terraform plan
+   module.test-vm.data.yandex_compute_image.my_image: Reading...
+   data.template_file.userdata: Reading...
+   module.vpc.yandex_vpc_network.net_name: Refreshing state... [id=enpjchrqk9unqff5gajr]
+   data.template_file.userdata: Read complete after 0s [id=a188abb0daeef04def27c9164c98402a79667f6164cd2816a7b9664d4afba9a1]
+   module.test-vm.data.yandex_compute_image.my_image: Read complete after 2s [id=fd8lape4adm5melne14m]
+   module.vpc.yandex_vpc_subnet.subnet_name: Refreshing state... [id=e9b4go0gvvkq6q8plbf0]
+   module.test-vm.yandex_compute_instance.vm[0]: Refreshing state... [id=fhm5mc92ioq0pk5bu04u]
+
+   No changes. Your infrastructure matches the configuration.
+
+   Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
+   fedor@fedor-Z68P-DS3:~/CODE/Netology/DevOps/ter-homeworks/04/src$
+   ```


### PR DESCRIPTION
Ошибки tflint:
   
```
fedor@fedor-Z68P-DS3:~/CODE/Netology/DevOps/ter-homeworks/04/src$ sudo docker run --rm -v "$(pwd):/tflint" ghcr.io/terraform-linters/tflint /tflint
[sudo] password for fedor:       
WARNING: "tflint FILE/DIR" is deprecated and will error in a future version. Use --chdir or --filter instead.
8 issue(s) found:

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on tflint/main.tf line 10:
  10:   source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_module_pinned_source.md

Warning: Missing version constraint for provider "template" in "required_providers" (terraform_required_providers)

  on tflint/main.tf line 27:
  27: data template_file "userdata" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md

Warning: Missing version constraint for provider "yandex" in "required_providers" (terraform_required_providers)

  on tflint/providers.tf line 24:
  24: provider "yandex" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md

Warning: variable "default_cidr" is declared but not used (terraform_unused_declarations)

  on tflint/variables.tf line 22:
  22: variable "default_cidr" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_unused_declarations.md

Warning: variable "vpc_name" is declared but not used (terraform_unused_declarations)

  on tflint/variables.tf line 28:
  28: variable "vpc_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_unused_declarations.md

Warning: variable "vms_ssh_root_key" is declared but not used (terraform_unused_declarations)

  on tflint/variables.tf line 36:
  36: variable "vms_ssh_root_key" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_unused_declarations.md

Warning: variable "vm_web_name" is declared but not used (terraform_unused_declarations)

  on tflint/variables.tf line 43:
  43: variable "vm_web_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_unused_declarations.md

Warning: variable "vm_db_name" is declared but not used (terraform_unused_declarations)

  on tflint/variables.tf line 50:
  50: variable "vm_db_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_unused_declarations.md
```
Ошибки checkov:

```
       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By bridgecrew.io | version: 2.3.273 

terraform scan results:

Passed checks: 1, Failed checks: 2, Skipped checks: 0

Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
	PASSED for resource: module.test-vm.yandex_compute_instance.vm[0]
	File: /.external_modules/github.com/udjin10/yandex_compute_instance/main/main.tf:24-73
	Calling File: /main.tf:9-25
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
	FAILED for resource: module.test-vm.yandex_compute_instance.vm[0]
	File: /.external_modules/github.com/udjin10/yandex_compute_instance/main/main.tf:24-73
	Calling File: /main.tf:9-25

		Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
	FAILED for resource: module.test-vm.yandex_compute_instance.vm[0]
	File: /.external_modules/github.com/udjin10/yandex_compute_instance/main/main.tf:24-73
	Calling File: /main.tf:9-25

		Code lines for this resource are too many. Please use IDE of your choice to review the file
```
План изменений:
```
Acquiring state lock. This may take a few moments...
data.template_file.userdata: Reading...
data.template_file.userdata: Read complete after 0s [id=a188abb0daeef04def27c9164c98402a79667f6164cd2816a7b9664d4afba9a1]
module.test-vm.data.yandex_compute_image.my_image: Reading...
module.vpc.yandex_vpc_network.net_name: Refreshing state... [id=enpuj2g11dke4d5fnbk6]
module.test-vm.data.yandex_compute_image.my_image: Read complete after 2s [id=fd8lape4adm5melne14m]
module.vpc.yandex_vpc_subnet.subnet_name: Refreshing state... [id=e9b6drerqnpu114c4983]
module.test-vm.yandex_compute_instance.vm[0]: Refreshing state... [id=fhm87ljbsavhabmlp09b]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # yandex_vpc_security_group.example will be created
  + resource "yandex_vpc_security_group" "example" {
      + created_at = (known after apply)
      + folder_id  = "b1go2coto23a6o9qniv9"
      + id         = (known after apply)
      + labels     = (known after apply)
      + name       = "example_dynamic"
      + network_id = "e9b6drerqnpu114c4983"
      + status     = (known after apply)

      + egress {
          + description    = "разрешить весь исходящий трафик"
          + from_port      = 0
          + id             = (known after apply)
          + labels         = (known after apply)
          + port           = -1
          + protocol       = "TCP"
          + to_port        = 65365
          + v4_cidr_blocks = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks = []
        }

      + ingress {
          + description    = "разрешить входящий  http"
          + from_port      = -1
          + id             = (known after apply)
          + labels         = (known after apply)
          + port           = 80
          + protocol       = "TCP"
          + to_port        = -1
          + v4_cidr_blocks = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks = []
        }
      + ingress {
          + description    = "разрешить входящий https"
          + from_port      = -1
          + id             = (known after apply)
          + labels         = (known after apply)
          + port           = 443
          + protocol       = "TCP"
          + to_port        = -1
          + v4_cidr_blocks = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks = []
        }
      + ingress {
          + description    = "разрешить входящий ssh"
          + from_port      = -1
          + id             = (known after apply)
          + labels         = (known after apply)
          + port           = 22
          + protocol       = "TCP"
          + to_port        = -1
          + v4_cidr_blocks = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks = []
        }
    }

  # module.test-vm.yandex_compute_instance.vm[0] will be updated in-place
  ~ resource "yandex_compute_instance" "vm" {
        id                        = "fhm87ljbsavhabmlp09b"
        name                      = "develop-web-0"
        # (12 unchanged attributes hidden)

      ~ network_interface {
          ~ nat                = true -> false
          ~ security_group_ids = [] -> (known after apply)
            # (8 unchanged attributes hidden)
        }

        # (5 unchanged blocks hidden)
    }

Plan: 1 to add, 1 to change, 0 to destroy.
```